### PR TITLE
Stop admins from not needing their old password.

### DIFF
--- a/application/controllers/settings/users.php
+++ b/application/controllers/settings/users.php
@@ -106,7 +106,7 @@ class Users extends My_Controller {
 			if($this->mylogin->user()->is_admin() || $this->mylogin->user()->id() == $this->user->id()){
 				
 				//if they are not admin check their old password is right
-				if(!$this->mylogin->user()->is_admin()){
+				if(!$this->mylogin->user()->is_admin() || $this->mylogin->user()->id() == $this->user->id()){
 					if(!$this->mylogin->check_password($this->input->post('old_password',''))){
 						$this->json->setData(false);
 						$this->json->setMessage('Old password was not correct');


### PR DESCRIPTION
Currently admin's do not need their old password to change their password. This allows for drive by workstation hot seat password changing. I have fixed now fixed this.